### PR TITLE
Upgrade to chartjs 2.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+bower_components
+node_modules

--- a/bower.json
+++ b/bower.json
@@ -7,10 +7,10 @@
     "wrapper"
   ],
   "dependencies": {
-    "webcomponentsjs": "Polymer/webcomponentsjs#0.6",
-    "polymer": "Polymer/polymer#0.8.0-rc.7",
-    "iron-component-page": "PolymerElements/iron-component-page#master",
-    "chartjs": "*"
+    "webcomponentsjs": "Polymer/webcomponentsjs#^0.7",
+    "polymer": "Polymer/polymer#^1.4",
+    "iron-component-page": "PolymerElements/iron-component-page#^1.1",
+    "chartjs": "chartjs/Chart.js#^2.0"
   },
   "main": "chartjs-element.html",
   "ignore": []

--- a/chartjs-element.html
+++ b/chartjs-element.html
@@ -87,7 +87,6 @@ license that can be found in the LICENSE file.
 
         chart: {
           type: Object,
-          observer: '_chartChanged',
           computed: '_computeChart(kind, options, ctx, _chartData)'
         }
 
@@ -106,13 +105,10 @@ license that can be found in the LICENSE file.
       },
 
       _computeChart: function(kind, options, ctx, _chartData) {
-        return new Chart(ctx, {type: kind, data: _chartData, options: options})
-      },
-
-      _chartChanged: function(chart, old) {
-        if (old) {
-          old.destroy();
+        if (this.chart) {
+          this.chart.destroy();
         }
+        return new Chart(ctx, {type: kind, data: _chartData, options: options})
       },
 
       _computeChartData: function(datasets, labels) {

--- a/chartjs-element.html
+++ b/chartjs-element.html
@@ -53,18 +53,19 @@ license that can be found in the LICENSE file.
 
       properties: {
 
-        colors: {
+        labels: {
           type: Array,
-          value: ['#AABBDD']
+          value: ['January','February','March','April','May','June','July']
         },
 
-        data: {
-          type: Object,
-          value: {
-            labels: ['January','February','March','April','May','June','July'],
+        datasets: {
+          type: Array,
+          value: [{
+            colors: ['#FF6384'],
             data: [28,48,40,19,96,27,100],
-            name: 'chart'
-          }
+            name: 'chart',
+            fill: true
+          }]
         },
 
         options: {
@@ -81,7 +82,7 @@ license that can be found in the LICENSE file.
 
         _chartData: {
           type: Object,
-          computed: '_computeChartData(data, colors)'
+          computed: '_computeChartData(datasets, labels)'
         },
 
         chart: {
@@ -114,24 +115,24 @@ license that can be found in the LICENSE file.
         }
       },
 
-      _computeChartData: function(data, colors) {
-        if (data) {
-          var labels = data.labels;
-          var dataPts = data.data;
-          var dataName = data.name;
-        }
+      _computeChartData: function(datasets, labels) {
+        var dataPts = [];
 
-        var rgbColors = colors.map(this.hexToRgb).map(this.rgbToString);
-        var dataset = {
-          backgroundColor : rgbColors.length == 1 ? rgbColors[0] : rgbColors,
-          pointHoverColor : rgbColors.length == 1 ? rgbColors[0] : rgbColors,
-          pointBorderColor: '#fff',
-          data: dataPts,
-          label: dataName
-        };
+        datasets.forEach(d => {
+          var rgbColors = d.colors.map(this.hexToRgb).map(this.rgbToString);
+          dataPts.push({
+            fill: d.fill == undefined ? false : d.fill,
+            backgroundColor : rgbColors.length == 1 ? rgbColors[0] : rgbColors,
+            borderColor : rgbColors.length == 1 ? rgbColors[0] : '#ffffff',
+            pointHoverColor : rgbColors.length == 1 ? rgbColors[0] : rgbColors,
+            pointBorderColor: rgbColors.length == 1 ? rgbColors[0] : rgbColors,
+            data: d.data,
+            label: d.name
+          });
+        });
         return {
           labels: labels,
-          datasets: [dataset]
+          datasets: dataPts
         };
       },
 

--- a/chartjs-element.html
+++ b/chartjs-element.html
@@ -29,7 +29,7 @@ license that can be found in the LICENSE file.
  @license Three-clause BSD
 -->
 
-<dom-module name="chartjs-element">
+<dom-module id="chartjs-element">
 
   <style>
     :host {
@@ -53,16 +53,17 @@ license that can be found in the LICENSE file.
 
       properties: {
 
-        color: {
-          type: String,
-          value: '#AABBDD'
+        colors: {
+          type: Array,
+          value: ['#AABBDD']
         },
 
         data: {
           type: Object,
           value: {
             labels: ['January','February','March','April','May','June','July'],
-            data: [28,48,40,19,96,27,100]
+            data: [28,48,40,19,96,27,100],
+            name: 'chart'
           }
         },
 
@@ -74,13 +75,13 @@ license that can be found in the LICENSE file.
         kind: {
           type: String,
           value: function() {
-            return ['Radar', 'Line', 'Bar'][Math.floor(Math.random()*3)];
+            return ['radar', 'line', 'bar'][Math.floor(Math.random()*3)];
           }
         },
 
         _chartData: {
           type: Object,
-          computed: '_computeChartData(data, color)'
+          computed: '_computeChartData(data, colors)'
         },
 
         chart: {
@@ -104,9 +105,7 @@ license that can be found in the LICENSE file.
       },
 
       _computeChart: function(kind, options, ctx, _chartData) {
-        var chart = new Chart(ctx);
-        var factory = chart[kind] || chart.Line;
-        return factory.call(chart, _chartData, options);
+        return new Chart(ctx, {type: kind, data: _chartData, options: options})
       },
 
       _chartChanged: function(chart, old) {
@@ -115,23 +114,29 @@ license that can be found in the LICENSE file.
         }
       },
 
-      _computeChartData: function(data, color) {
+      _computeChartData: function(data, colors) {
         if (data) {
           var labels = data.labels;
           var dataPts = data.data;
+          var dataName = data.name;
         }
-        var rgbColor = this.hexToRgb(color).join(',');
+
+        var rgbColors = colors.map(this.hexToRgb).map(this.rgbToString);
         var dataset = {
-          fillColor : 'rgba(' + rgbColor + ', 0.5)',
-          strokeColor : 'rgba(' + rgbColor + ', 1)',
-          pointColor : 'rgba(' + rgbColor + ', 1)',
-          pointStrokeColor: '#fff',
-          data: dataPts
+          backgroundColor : rgbColors.length == 1 ? rgbColors[0] : rgbColors,
+          pointHoverColor : rgbColors.length == 1 ? rgbColors[0] : rgbColors,
+          pointBorderColor: '#fff',
+          data: dataPts,
+          label: dataName
         };
         return {
           labels: labels,
           datasets: [dataset]
         };
+      },
+
+      rgbToString: function(array) {
+        return 'rgba(' + array.join(',') + ', 0.5)'
       },
 
       hexToRgb: function(hex) {

--- a/chartjs-element.html
+++ b/chartjs-element.html
@@ -41,7 +41,7 @@ license that can be found in the LICENSE file.
 
   <template>
 
-    <canvas id="chart" width="{{width}}" height="{{height}}"></canvas>
+    <div><canvas id="chart" width="{{width}}" height="{{height}}"></canvas></div>
 
   </template>
 

--- a/chartjs-element.html
+++ b/chartjs-element.html
@@ -113,9 +113,10 @@ license that can be found in the LICENSE file.
 
       _computeChartData: function(datasets, labels) {
         var dataPts = [];
+        var that = this;
 
-        datasets.forEach(d => {
-          var rgbColors = d.colors.map(this.hexToRgb).map(this.rgbToString);
+        datasets.forEach(function(d) {
+          var rgbColors = d.colors.map(that.hexToRgb).map(that.rgbToString);
           dataPts.push({
             fill: d.fill == undefined ? false : d.fill,
             backgroundColor : rgbColors.length == 1 ? rgbColors[0] : rgbColors,

--- a/chartjs-import.html
+++ b/chartjs-import.html
@@ -8,4 +8,4 @@
  @origin-url http://www.chartjs.org/
  @license Three-clause BSD
 -->
-<script src="../chartjs/Chart.min.js"></script>
+<script src="../chartjs/dist/Chart.min.js"></script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -36,16 +36,98 @@
 </head>
 
 <body>
-
+<span id="browser-sync-binding"></span>
 <chartjs-element></chartjs-element>
-<chartjs-element kind="line" colors='["ff0000"]'></chartjs-element>
-<chartjs-element kind="radar" data='{"name": "Fruits", "data": [6, 12, 30, 16], "labels": ["Apples", "Bananas", "Cherries", "Dates"]}' colors='["008000"]'></chartjs-element>
-<chartjs-element kind="pie" data='{"data": [6, 12, 30, 16], "labels": ["Apples", "Bananas", "Cherries", "Dates"]}' colors='["DB00DB", "FF0000", "00FF00", "0000FF"]'></chartjs-element>
-<chartjs-element kind="doughnut" data='{"data": [6, 12, 30, 16], "labels": ["Apples", "Bananas", "Cherries", "Dates"]}' colors='["DFE32D", "FF0000", "00FF00", "0000FF"]'></chartjs-element>
-<chartjs-element kind="bubble" data='{"name": "Bubble", "data": [{"x": 3, "y": 3, "r": 10}, {"x": 4, "y": 4, "r": 30}, {"x": 6, "y": 4, "r": 15}, {"x": 8, "y": 5, "r": 4}]}' colors='["1B85B8", "FF0000", "00FF00", "0000FF"]'></chartjs-element>
-<chartjs-element kind="polarArea" data='{"data": [6, 12, 30, 16], "labels": ["Apples", "Bananas", "Cherries", "Dates"]}' colors='["5757FF", "FF0000", "00FF00", "0000FF"]'></chartjs-element>
-<chartjs-element kind="scatter" data='{"name": "Fruits", "data": [6, 12, 30, 16], "labels": ["Apples", "Bananas", "Cherries", "Dates"]}' colors='["06DCFB", "FF0000", "00FF00", "0000FF"]'></chartjs-element>
-<chartjs-element kind="bar" data='{"name": "Fruits", "data": [6, 12, 30, 16], "labels": ["Apples", "Bananas", "Cherries", "Dates"]}' colors='["59DF00", "FF0000", "00FF00", "0000FF"]'></chartjs-element>
+<chartjs-element id="line-chart"></chartjs-element>
+<chartjs-element id="radar-chart"></chartjs-element>
+<chartjs-element id="pie-chart"></chartjs-element>
+<chartjs-element id="doughnut-chart"></chartjs-element>
+<chartjs-element id="bubble-chart"></chartjs-element>
+<chartjs-element id="polar-area-chart"></chartjs-element>
+<chartjs-element id="scatter-chart"></chartjs-element>
+<chartjs-element id="bar-chart"></chartjs-element>
 
 </body>
+
+<script>
+  (function() {
+    var doughnutChart = document.querySelector('#doughnut-chart');
+    var doughnutChartColors = ["DFE32D", "FF0000", "00FF00", "0000FF"];
+    doughnutChart.datasets = [];
+    doughnutChart.datasets.push({data: [6, 12, 30, 16], name: "city", colors: doughnutChartColors});
+    doughnutChart.datasets.push({data: [3, 6, 9, 12], name: "province", colors: doughnutChartColors});
+    doughnutChart.labels = ["Chapels", "Bananas", "Cherries", "Dates"];
+    doughnutChart.kind= "doughnut";
+  })();
+
+  (function() {
+    var lineChart = document.querySelector('#line-chart');
+    lineChart.datasets = [];
+    lineChart.datasets.push({data: [6, 12, 20, 16], name: "city", colors: ["DFE32D"]});
+    lineChart.datasets.push({data: [3, 6, 9, 12], name: "province", colors: ["FF0000"]});
+    lineChart.datasets.push({data: [3, 4, 5, 3], name: "village", colors: ["00FF00"]});
+    lineChart.datasets.push({data: [9, 6, 3, 14], name: "coast", colors: ["0000FF"]});
+    lineChart.datasets.push({data: [2, 9, 3, 5], name: "mountain", colors: ["F000F0"]});
+    lineChart.labels = ["Chapels", "Bananas", "Cherries", "Dates"];
+    lineChart.kind= "line";
+  })();
+
+  (function() {
+    var radarChart = document.querySelector('#radar-chart');
+    radarChart.datasets = [];
+    radarChart.datasets.push({data: [6, 12, 20, 16], name: "city", colors: ["008000"]});
+    radarChart.datasets.push({data: [3, 6, 9, 12], name: "province", colors: ["FF0000"]});
+    radarChart.labels = ["Chapels", "Bananas", "Cherries", "Dates"];
+    radarChart.kind= "radar";
+  })();
+
+  (function() {
+    var pieChart = document.querySelector('#pie-chart');
+    var pieChartColors = ["DB00DB", "FF0000", "00FF00", "0000FF"];
+    pieChart.datasets = [];
+    pieChart.datasets.push({data: [6, 12, 20, 16], name: "city", colors: pieChartColors});
+    pieChart.datasets.push({data: [3, 6, 9, 12], name: "province", colors: pieChartColors});
+    pieChart.labels = ["Chapels", "Bananas", "Cherries", "Dates"];
+    pieChart.kind= "pie";
+  })();
+
+  (function() {
+    data={"name": "Bubble"}
+    var bubbleChart = document.querySelector('#bubble-chart');
+    var bubbleChartColors = ["1B85B8", "FF0000", "00FF00", "0000FF"];
+    bubbleChart.datasets = [];
+    bubbleChartData = [{"x": 3, "y": 3, "r": 10}, {"x": 4, "y": 4, "r": 30}, {"x": 6, "y": 4, "r": 15}, {"x": 8, "y": 5, "r": 4}];
+    bubbleChart.datasets.push({data: bubbleChartData, name: "Fruits", colors: bubbleChartColors});
+    bubbleChart.labels = ["Chapels", "Bananas", "Cherries", "Dates"];
+    bubbleChart.kind= "bubble";
+  })();
+
+  (function() {
+    var polarAreaChart = document.querySelector('#polar-area-chart');
+    var polarChartColors=["5757FF", "FF0000", "00FF00", "0000FF"];
+    polarAreaChart.datasets = [];
+    polarAreaChart.datasets.push({data: [6, 12, 20, 16], name: "city", colors: polarChartColors});
+    polarAreaChart.labels = ["Chapels", "Bananas", "Cherries", "Dates"];
+    polarAreaChart.kind= "polarArea";
+  })();
+
+  (function() {
+    var scatterChart = document.querySelector('#scatter-chart');
+    scatterChart.datasets = [];
+    scatterChart.datasets.push({data: [6, 12, 20, 16], name: "city", colors: ["06DCFB"], fill: true});
+    scatterChart.datasets.push({data: [15, 14, 13, 12], name: "province", colors: ["FF0000"], fill: true});
+    scatterChart.labels = ["Chapels", "Bananas", "Cherries", "Dates"];
+    scatterChart.kind= "scatter";
+  })();
+
+  (function() {
+    var barChart = document.querySelector('#bar-chart');
+    barChart.datasets = [];
+    barChart.datasets.push({data: [6, 12, 20, 16], name: "city", colors: ["59DF00"]});
+    barChart.datasets.push({data: [3, 6, 9, 12], name: "province", colors: ["FF0000"]});
+    barChart.labels = ["Chapels", "Bananas", "Cherries", "Dates"];
+    barChart.kind= "bar";
+  })();
+
+</script>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -31,8 +31,14 @@
 <body>
 
 <chartjs-element></chartjs-element>
-<chartjs-element kind="Line" color="ff0000"></chartjs-element>
-<chartjs-element kind="Radar" data='{"data": [6, 12, 30, 16], "labels": ["Apples", "Bananas", "Cherries", "Dates"]}' color="008000"></chartjs-element>
+<chartjs-element kind="line" colors='["ff0000"]'></chartjs-element>
+<chartjs-element kind="radar" data='{"name": "Fruits", "data": [6, 12, 30, 16], "labels": ["Apples", "Bananas", "Cherries", "Dates"]}' colors='["008000"]'></chartjs-element>
+<chartjs-element kind="pie" data='{"data": [6, 12, 30, 16], "labels": ["Apples", "Bananas", "Cherries", "Dates"]}' colors='["DB00DB", "FF0000", "00FF00", "0000FF"]'></chartjs-element>
+<chartjs-element kind="doughnut" data='{"data": [6, 12, 30, 16], "labels": ["Apples", "Bananas", "Cherries", "Dates"]}' colors='["DFE32D", "FF0000", "00FF00", "0000FF"]'></chartjs-element>
+<chartjs-element kind="bubble" data='{"name": "Bubble", "data": [{"x": 3, "y": 3, "r": 10}, {"x": 4, "y": 4, "r": 30}, {"x": 6, "y": 4, "r": 15}, {"x": 8, "y": 5, "r": 4}]}' colors='["1B85B8", "FF0000", "00FF00", "0000FF"]'></chartjs-element>
+<chartjs-element kind="polarArea" data='{"data": [6, 12, 30, 16], "labels": ["Apples", "Bananas", "Cherries", "Dates"]}' colors='["5757FF", "FF0000", "00FF00", "0000FF"]'></chartjs-element>
+<chartjs-element kind="scatter" data='{"name": "Fruits", "data": [6, 12, 30, 16], "labels": ["Apples", "Bananas", "Cherries", "Dates"]}' colors='["06DCFB", "FF0000", "00FF00", "0000FF"]'></chartjs-element>
+<chartjs-element kind="bar" data='{"name": "Fruits", "data": [6, 12, 30, 16], "labels": ["Apples", "Bananas", "Cherries", "Dates"]}' colors='["59DF00", "FF0000", "00FF00", "0000FF"]'></chartjs-element>
 
 </body>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,7 +13,14 @@
 
   <title>ChartJS</title>
 
-  <script src="../../webcomponentsjs/webcomponents.js"></script>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script>
+    /* this script must run before Polymer is imported */
+    window.Polymer = {
+      dom: 'shadow',
+      lazyRegister: true
+    };
+  </script>
   <link rel="import" href="../chartjs-element.html">
 
   <style>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,205 @@
+'use strict';
+
+// Include promise polyfill for node 0.10 compatibility
+require('es6-promise').polyfill();
+
+// Include Gulp & tools we'll use
+var gulp = require('gulp');
+var $ = require('gulp-load-plugins')();
+var del = require('del');
+var runSequence = require('run-sequence');
+var browserSync = require('browser-sync');
+var reload = browserSync.reload;
+var merge = require('merge-stream');
+var path = require('path');
+var fs = require('fs');
+var glob = require('glob-all');
+var historyApiFallback = require('connect-history-api-fallback');
+var packageJson = require('./package.json');
+var crypto = require('crypto');
+
+var AUTOPREFIXER_BROWSERS = [
+  'ie >= 10',
+  'ie_mob >= 10',
+  'ff >= 30',
+  'chrome >= 34',
+  'safari >= 7',
+  'opera >= 23',
+  'ios >= 7',
+  'android >= 4.4',
+  'bb >= 10'
+];
+
+var DIST = 'dist';
+
+var dist = function(subpath) {
+  return !subpath ? DIST : path.join(DIST, subpath);
+};
+
+var optimizeHtmlTask = function(src, dest) {
+  var assets = $.useref.assets({
+    searchPath: ['.tmp', 'demo']
+  });
+
+  return gulp.src(src)
+    .pipe(assets)
+    // Concatenate and minify JavaScript
+    .pipe($.if('*.js', $.uglify({
+      preserveComments: 'some'
+    })))
+    // Concatenate and minify styles
+    // In case you are still using useref build blocks
+    .pipe($.if('*.css', $.minifyCss()))
+    .pipe(assets.restore())
+    .pipe($.useref())
+    // Minify any HTML
+    .pipe($.if('*.html', $.minifyHtml({
+      quotes: true,
+      empty: true,
+      spare: true
+    })))
+    // Output files
+    .pipe(gulp.dest(dest))
+    .pipe($.size({
+      title: 'html'
+    }));
+};
+
+// Copy all files at the root level (demo)
+gulp.task('copy', function() {
+  var demo = gulp.src([
+    'demo/*',
+    '!**/.DS_Store'
+  ], {
+    dot: true
+  }).pipe(gulp.dest(dist()));
+
+  // Copy over only the bower_components we need
+  // These are things which cannot be vulcanized
+  var bower = gulp.src([
+    'bower_components/{webcomponentsjs,platinum-sw,sw-toolbox,promise-polyfill}/**/*'
+  ]).pipe(gulp.dest(dist('bower_components')));
+
+  return merge(demo, bower)
+    .pipe($.size({
+      title: 'copy'
+    }));
+});
+
+// Scan your HTML for assets & optimize them
+gulp.task('html', function() {
+  return optimizeHtmlTask(
+    ['demo/**/*.html'],
+    dist());
+});
+
+// Vulcanize granular configuration
+gulp.task('vulcanize', function() {
+  return gulp.src('chartjs-element.html')
+    .pipe($.vulcanize({
+      stripComments: true,
+      inlineCss: true,
+      inlineScripts: true
+    }))
+    .pipe(gulp.dest(dist('elements')))
+    .pipe($.size({title: 'vulcanize'}));
+});
+
+// Generate config data for the <sw-precache-cache> element.
+// This include a list of files that should be precached, as well as a (hopefully unique) cache
+// id that ensure that multiple PSK projects don't share the same Cache Storage.
+// This task does not run by default, but if you are interested in using service worker caching
+// in your project, please enable it within the 'default' task.
+// See https://github.com/PolymerElements/polymer-starter-kit#enable-service-worker-support
+// for more context.
+gulp.task('cache-config', function(callback) {
+  var dir = dist();
+  var config = {
+    cacheId: packageJson.name || path.basename(__dirname),
+    disabled: false
+  };
+
+  glob([
+    'demo/index.html',
+    './',
+    '{elements,scripts,styles}/**/*.*'],
+    {cwd: dir}, function(error, files) {
+    if (error) {
+      callback(error);
+    } else {
+      config.precache = files;
+
+      var md5 = crypto.createHash('md5');
+      md5.update(JSON.stringify(config.precache));
+      config.precacheFingerprint = md5.digest('hex');
+
+      var configPath = path.join(dir, 'cache-config.json');
+      fs.writeFile(configPath, JSON.stringify(config), callback);
+    }
+  });
+});
+
+// Clean output directory
+gulp.task('clean', function() {
+  return del(['.tmp', dist()]);
+});
+
+// Watch files for changes & reload
+gulp.task('serve', function() {
+  browserSync({
+    port: 5001,
+    notify: false,
+    logPrefix: 'chel',
+    snippetOptions: {
+      rule: {
+        match: '<span id="browser-sync-binding"></span>',
+        fn: function(snippet) {
+          return snippet;
+        }
+      }
+    },
+    // Run as an https by uncommenting 'https: true'
+    // Note: this uses an unsigned certificate which on first access
+    //       will present a certificate warning in the browser.
+    // https: true,
+    server: {
+      baseDir: ['.tmp', 'demo', '.', 'bower_components'],
+      middleware: [historyApiFallback()]
+    }
+  });
+
+  gulp.watch(['demo/**/*.html', '*.html'], reload);
+});
+
+// Build and serve the output from the dist build
+gulp.task('serve:dist', ['default'], function() {
+  browserSync({
+    port: 5001,
+    notify: false,
+    logPrefix: 'chel',
+    snippetOptions: {
+      rule: {
+        match: '<span id="browser-sync-binding"></span>',
+        fn: function(snippet) {
+          return snippet;
+        }
+      }
+    },
+    // Run as an https by uncommenting 'https: true'
+    // Note: this uses an unsigned certificate which on first access
+    //       will present a certificate warning in the browser.
+    // https: true,
+    server: dist(),
+    middleware: [historyApiFallback()]
+  });
+});
+
+// Build production files, the default task
+gulp.task('default', ['clean'], function(cb) {
+  // Uncomment 'cache-config' if you are going to use service workers.
+  runSequence(
+    ['copy', 'styles'],
+    ['html'],
+    'vulcanize', // 'cache-config',
+    cb);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,39 @@
+{
+  "private": true,
+  "devDependencies": {
+    "browser-sync": "^2.7.7",
+    "connect-history-api-fallback": "^1.1.0",
+    "del": "^2.0.2",
+    "es6-promise": "^3.1.2",
+    "glob-all": "^3.0.1",
+    "gulp": "^3.8.5",
+    "gulp-autoprefixer": "^3.1.0",
+    "gulp-cache": "^0.4.0",
+    "gulp-changed": "^1.0.0",
+    "gulp-gh-pages": "^0.5.4",
+    "gulp-html-extract": "^0.1.0",
+    "gulp-if": "^2.0.0",
+    "gulp-imagemin": "^2.2.1",
+    "gulp-load-plugins": "^1.1.0",
+    "gulp-minify-css": "^1.2.1",
+    "gulp-minify-html": "^1.0.2",
+    "gulp-rename": "^1.2.0",
+    "gulp-replace": "^0.5.4",
+    "gulp-size": "^2.0.0",
+    "gulp-uglify": "^1.2.0",
+    "gulp-useref": "^2.1.0",
+    "gulp-vulcanize": "^6.0.0",
+    "merge-stream": "^1.0.0",
+    "require-dir": "^0.3.0",
+    "run-sequence": "^1.0.2",
+    "vulcanize": ">= 1.4.2",
+    "web-component-tester": "^4.0.0"
+  },
+  "scripts": {
+    "test": "gulp test:local",
+    "start": "gulp serve"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  }
+}


### PR DESCRIPTION
Instead of forcing the bower dependency to chartjs 1.x.x, I've updated the code to match the latest API changes introduced in the chartjs 2.0 release. I've also enriched the demo with the eight different chart types. While doing so, I found it reasonable to allow declaration of multiple colors.

Extra:
- Support for shadow dom (div wrapper needed on chartjs-element to avoid chartjs error on resize when getting canvas parent)

Resolves issue #4 
